### PR TITLE
Remove type alias from hw3

### DIFF
--- a/hw3/README.md
+++ b/hw3/README.md
@@ -16,7 +16,6 @@ You will finish the parser in HW4 and HW5.
 ```
 cmd  : read image <string> to <argument>
      | write image <expr> to <string>
-     | type <variable> = <type>
      | let <lvalue> = <expr>
      | assert <expr> , <string>
      | print <string>

--- a/hw3/README.md
+++ b/hw3/README.md
@@ -132,7 +132,6 @@ The AST node names that you must use in your S-expression output are:
 ```
 ReadCmd
 WriteCmd
-TypeCmd
 LetCmd
 AssertCmd
 PrintCmd


### PR DESCRIPTION
This syntax for type alias is not in the spec this year. It looks like it came from the [last version of the class](https://github.com/utah-cs4470-sp23/class/blob/2023/spec.md#commands). 